### PR TITLE
Switch active network

### DIFF
--- a/src/exconfig.ts
+++ b/src/exconfig.ts
@@ -1,17 +1,13 @@
-// eslint-disable-next-line import/no-anonymous-default-export
-export default {
-  enablePasswordEncryption: false,
-  showTransactionConfirmationScreen: true,
-  factory_address: '0x09c58cf6be8E25560d479bd52B4417d15bCA2845',
-  stateVersion: '0.1',
-  network: {
+import { EVMNetwork } from './pages/Background/types/network';
+
+const networks: EVMNetwork[] = [
+  {
     chainID: '5',
     family: 'EVM',
-    name: 'Goerli',
-    provider: 'https://goerli.infura.io/v3/bdabe9d2f9244005af0f566398e648da',
+    name: 'LocalGoerli',
+    provider: 'http://localhost:8545',
     entryPointAddress: '0x0576a174D229E3cFA37253523E645A78A0C91B57',
-    bundler:
-      'https://node.stackup.sh/v1/rpc/420c8ba682cabe5ab405980e35c9b218af18f4702c46aaec4627ba9050fcc4ee',
+    bundler: 'http://localhost:4337',
     baseAsset: {
       symbol: 'ETH',
       name: 'ETH',
@@ -20,4 +16,28 @@ export default {
         'https://ethereum.org/static/6b935ac0e6194247347855dc3d328e83/6ed5f/eth-diamond-black.webp',
     },
   },
+  {
+    chainID: '11155111',
+    family: 'EVM',
+    name: 'LocalSepolia',
+    provider: 'http://localhost:9545',
+    entryPointAddress: '0x0576a174D229E3cFA37253523E645A78A0C91B57',
+    bundler: 'http://localhost:5337',
+    baseAsset: {
+      symbol: 'ETH',
+      name: 'ETH',
+      decimals: 18,
+      image:
+        'https://ethereum.org/static/6b935ac0e6194247347855dc3d328e83/6ed5f/eth-diamond-black.webp',
+    },
+  },
+];
+
+// eslint-disable-next-line import/no-anonymous-default-export
+export default {
+  enablePasswordEncryption: false,
+  showTransactionConfirmationScreen: true,
+  factory_address: '0x09c58cf6be8E25560d479bd52B4417d15bCA2845',
+  stateVersion: '0.1',
+  networks,
 };

--- a/src/pages/App/components/header/header.tsx
+++ b/src/pages/App/components/header/header.tsx
@@ -1,12 +1,11 @@
 import {
   Box,
-  Container,
   FormControl,
   InputLabel,
   MenuItem,
   Select,
+  SelectChangeEvent,
   Stack,
-  Typography,
 } from '@mui/material';
 import React from 'react';
 import logo from '../../../../assets/img/logo.svg';
@@ -17,11 +16,22 @@ import {
 import { useBackgroundSelector } from '../../hooks';
 import SettingsIcon from '@mui/icons-material/Settings';
 import { useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { setActiveNetwork } from '../../../Background/redux-slices/network';
 
 const Header = () => {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const activeNetwork = useBackgroundSelector(getActiveNetwork);
   const supportedNetworks = useBackgroundSelector(getSupportedNetworks);
+
+  const switchActiveNetwork = (e: SelectChangeEvent<string>) => {
+    const payload = supportedNetworks.find((network) => {
+      return network.chainID === e.target.value;
+    });
+    if (!payload) return;
+    dispatch(setActiveNetwork(payload));
+  };
 
   return (
     <Box
@@ -30,13 +40,7 @@ const Header = () => {
       flexDirection="row"
       justifyContent="space-between"
       alignItems="center"
-      sx={{
-        mr: 4,
-        ml: 4,
-        mt: 2,
-        mb: 2,
-        height: 60,
-      }}
+      sx={{ mr: 4, ml: 4, mt: 2, mb: 2, height: 60 }}
     >
       <Stack
         direction="row"
@@ -61,7 +65,7 @@ const Header = () => {
             id="chain-selector"
             value={activeNetwork.chainID}
             label="Chain"
-            // onChange={handleChange}
+            onChange={switchActiveNetwork}
           >
             {supportedNetworks.map((network) => (
               <MenuItem key={network.chainID} value={network.chainID}>

--- a/src/pages/Background/redux-slices/network.ts
+++ b/src/pages/Background/redux-slices/network.ts
@@ -13,7 +13,7 @@ export type NetworkState = {
   supportedNetworks: Array<EVMNetwork>;
 };
 
-const GoerliNetwork: EVMNetwork = Config.network || {
+const GoerliNetwork: EVMNetwork = Config.networks[0] || {
   chainID: '5',
   family: 'EVM',
   name: 'Goerli',
@@ -32,15 +32,25 @@ const GoerliNetwork: EVMNetwork = Config.network || {
 
 export const initialState: NetworkState = {
   activeNetwork: GoerliNetwork,
-  supportedNetworks: [GoerliNetwork],
+  supportedNetworks: Config.networks,
 };
 
-type NetworkReducers = {};
+type NetworkReducers = {
+  setActiveNetwork: (
+    state: NetworkState,
+    { payload }: { payload: EVMNetwork }
+  ) => void;
+};
 
 const networkSlice = createSlice<NetworkState, NetworkReducers, 'network'>({
   name: 'network',
   initialState,
-  reducers: {},
+  reducers: {
+    setActiveNetwork: (state, { payload }) => {
+      state.activeNetwork = payload;
+    },
+  },
 });
 
+export const { setActiveNetwork } = networkSlice.actions;
 export default networkSlice.reducer;


### PR DESCRIPTION
### This PR can switch active network.

https://user-images.githubusercontent.com/47471299/231543022-e4d22e4f-dcf6-44b8-9dc9-18c4214d6977.mov

### This is sample duplicate network definition.

```
import { EVMNetwork } from './pages/Background/types/network';

const networks: EVMNetwork[] = [
  {
    chainID: '5',
    family: 'EVM',
    name: 'LocalGoerli',
    provider: 'http://xxxxxxxx',
    entryPointAddress: '0x087654323456789098765,
    bundler: 'http://xxxxxxxxxxxxxx',
    baseAsset: {
      symbol: 'ETH',
      name: 'ETH',
      decimals: 18,
      image:
        'https://ethereum.org/static/6b935ac0e6194247347855dc3d328e83/6ed5f/eth-diamond-black.webp',
    },
  },
  {
    chainID: '11155111',
    family: 'EVM',
    name: 'LocalSepolia',
    provider: 'http://xxxxxxxx',
    entryPointAddress: '0x045676543456787654345678,
    bundler: 'http://xxxxxxxxxxxxxx',
    baseAsset: {
      symbol: 'ETH',
      name: 'ETH',
      decimals: 18,
      image:
        'https://ethereum.org/static/6b935ac0e6194247347855dc3d328e83/6ed5f/eth-diamond-black.webp',
    },
  },
];

// eslint-disable-next-line import/no-anonymous-default-export
export default {
  enablePasswordEncryption: false,
  showTransactionConfirmationScreen: true,
  factory_address: '0x09c58cf6be8E25560d479bd52B4417d15bCA2845',
  stateVersion: '0.1',
  networks,
};
```